### PR TITLE
Divide rate with 100

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -115,7 +115,7 @@ final class Money implements JsonSerializable, Arrayable, Wireable
     public function addFee(float $rate): self
     {
         return $this->multiplyBy(
-            round(1 + $rate, $this->currency->mathDecimals())
+            round(1 + ($rate / 100), $this->currency->mathDecimals())
         );
     }
 
@@ -129,7 +129,7 @@ final class Money implements JsonSerializable, Arrayable, Wireable
     public function subtractFee(float $rate): self
     {
         return $this->divideBy(
-            round(1 + $rate, $this->currency->mathDecimals())
+            round(1 + ($rate / 100), $this->currency->mathDecimals())
         );
     }
 

--- a/tests/Pest/MoneyTest.php
+++ b/tests/Pest/MoneyTest.php
@@ -104,19 +104,19 @@ test('money can be divided', function () {
 test('fees can be added to and subtracted from money', function () {
     $money = Money::fromDecimal(10.0);
 
-    expect($money->addFee(0.1)->decimal())->toBe(11.0);
-    expect($money->subtractFee(0.1)->decimal())->toBe(9.09); // 10/1.1
+    expect($money->addFee(10)->decimal())->toBe(11.0);
+    expect($money->subtractFee(10)->decimal())->toBe(9.09); // 10/1.1
 });
 
 test('taxes can be added and subtracted from money', function () {
     currencies()->add([CZK::class]);
 
     expect(
-        Money::fromDecimal(100.0, 'CZK')->addTax(0.21)->decimal()
+        Money::fromDecimal(100.0, 'CZK')->addTax(21.0)->decimal()
     )->toBe(121.0);
 
     expect(
-        Money::fromDecimal(121.0, 'CZK')->subtractTax(0.21)->decimal()
+        Money::fromDecimal(121.0, 'CZK')->subtractTax(21.0)->decimal()
     )->toBe(100.0);
 });
 


### PR DESCRIPTION
Needed for the calculation to be correct according to the documentation. 
`$money->addTax(20)` and not `$money->addTax(0.2)`

Of course, the easy way is just to update the documentation. But i would prefer the documented version as in this pull request e.g: `$money->addTax(20)`