### PR TITLE
Money instance creation from a formatted string

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,13 +166,13 @@ $money = Money::fromDecimal(40.25, USD::class);
 $money->formatted(['decimalSeparator' => ',', 'prefix' => '$ ', 'suffix' => ' USD']);
 ```
 
-There is also a `->rawFormatted()` if you wish to use [math decimals](#math-decimals) instead of [display decimals](#display-decimals).
+There's also `->rawFormatted()` if you wish to use [math decimals](#math-decimals) instead of [display decimals](#display-decimals).
 ```php
 $money = Money::new(123456, CZK::class);
-$money->rawFormatted(); // 1 235,56 Kč
+$money->rawFormatted(); // 1 234,56 Kč
 ```
 
-And converting the formatted value back to the Money instance is also possible. The package tries to extract the currency from the provided string.
+Converting the formatted value back to the `Money` instance is also possible. The package tries to extract the currency from the provided string:
 ```php
 $money = money(1000);
 $formatted = $money->formatted(); // $10.00

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ $money = Money::new(123456, CZK::class);
 $money->rawFormatted(); // 1 235,56 Kč
 ```
 
-And converting the formatted value back to the Money instance is also possible:
+And converting the formatted value back to the Money instance is also possible. The package tries to extract the currency from the provided string.
 ```php
 $money = money(1000);
 $formatted = $money->formatted(); // $10.00
@@ -180,7 +180,18 @@ $fromFormatted = Money::fromFormatted($formatted);
 $fromFormatted->is($money); // true
 ```
 
-Note: `fromFormatted()` misses the cents if the [math decimals](#math-decimals) are greater than [display decimals](#display-decimals).
+Optional overrides for the [currency specification](#currency-logic) are accepted too.
+```php
+$money = money(1000);
+$formatted = $money->formatted(); // $10.00
+$fromFormatted = Money::fromFormatted($formatted, USD::class, ['decimalSeparator' => ',', 'prefix' => '$ ', 'suffix' => ' USD']);
+$fromFormatted->is($money); // true
+```
+
+Notes:
+1) If currency is not specified and none of the currencies match the prefix and suffix, an exception will be thrown.
+2) If currency is not specified and multiple currencies use the same prefix and suffix, an exception will be thrown.
+3) `fromFormatted()` misses the cents if the [math decimals](#math-decimals) are greater than [display decimals](#display-decimals).
 
 ### Rounding money
 

--- a/README.md
+++ b/README.md
@@ -180,11 +180,11 @@ $fromFormatted = Money::fromFormatted($formatted);
 $fromFormatted->is($money); // true
 ```
 
-Optional overrides for the [currency specification](#currency-logic) are accepted too.
+If you had passed overrides while [formatting the money instance](#formatting-money), the same can passed to this method.
 ```php
 $money = money(1000);
-$formatted = $money->formatted(); // $10.00
-$fromFormatted = Money::fromFormatted($formatted, USD::class, ['decimalSeparator' => ',', 'prefix' => '$ ', 'suffix' => ' USD']);
+$formatted = $money->formatted(['prefix' => '$ ', 'suffix' => ' USD']); // $ 10.00 USD
+$fromFormatted = Money::fromFormatted($formatted, USD::class, ['prefix' => '$ ', 'suffix' => ' USD']);
 $fromFormatted->is($money); // true
 ```
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ $money->decimals(); // 100.0
 
 ### Formatting money
 
-You can format money using the `->formatted()` method:
+You can format money using the `->formatted()` method. It takes [display decimals](#display-decimals) into consideration.
 
 ```php
 $money = Money::fromDecimal(40.25, USD::class);
@@ -165,6 +165,22 @@ $money = Money::fromDecimal(40.25, USD::class);
 // $ 40.25 USD
 $money->formatted(['decimalSeparator' => ',', 'prefix' => '$ ', 'suffix' => ' USD']);
 ```
+
+There is also a `->rawFormatted()` if you wish to use [math decimals](#math-decimals) instead of [display decimals](#display-decimals).
+```php
+$money = Money::new(123456, CZK::class);
+$money->rawFormatted(); // 1 235,56 Kč
+```
+
+And converting the formatted value back to the Money instance is also possible:
+```php
+$money = money(1000);
+$formatted = $money->formatted(); // $10.00
+$fromFormatted = Money::fromFormatted($formatted);
+$fromFormatted->is($money); // true
+```
+
+Note: `fromFormatted()` misses the cents if the [math decimals](#math-decimals) are greater than [display decimals](#display-decimals).
 
 ### Rounding money
 
@@ -414,7 +430,7 @@ For the Czech Crown (CZK), the display decimals will be `0`, but the math decima
 
 For the inverse of what was just explained above, you can use the `rawFormatted()` method. This returns the formatted value, **but uses the math decimals for the display decimals**. Meaning, the value in the example above will be displayed including cents:
 ```php
-money(123456, new CZK)->rawFormatted(); // 1 235,56 Kč
+money(123456, new CZK)->rawFormatted(); // 1 234,56 Kč
 ```
 
 This is mostly useful for currencies like the Czech Crown which generally don't use cents, but **can** use them in specific cases.

--- a/src/Exceptions/CannotExtractCurrencyException.php
+++ b/src/Exceptions/CannotExtractCurrencyException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ArchTech\Money\Exceptions;
+
+use Exception;
+
+class CannotExtractCurrencyException extends Exception
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Money.php
+++ b/src/Money.php
@@ -174,6 +174,10 @@ final class Money implements JsonSerializable, Arrayable, Wireable
     /** Create a Money instance from a formatted string. */
     public static function fromFormatted(string $formatted, Currency|string $currency = null, mixed ...$overrides): self
     {
+        $currency = isset($currency)
+            ? currency($currency)
+            : PriceFormatter::extractCurrency($formatted);
+
         $decimal = PriceFormatter::resolve($formatted, currency($currency), variadic_array($overrides));
 
         return static::fromDecimal($decimal, currency($currency));

--- a/src/Money.php
+++ b/src/Money.php
@@ -178,7 +178,7 @@ final class Money implements JsonSerializable, Arrayable, Wireable
             ? currency($currency)
             : PriceFormatter::extractCurrency($formatted);
 
-        $decimal = PriceFormatter::resolve($formatted, currency($currency), variadic_array($overrides));
+        $decimal = PriceFormatter::resolve($formatted, $currency, variadic_array($overrides));
 
         return static::fromDecimal($decimal, currency($currency));
     }

--- a/src/Money.php
+++ b/src/Money.php
@@ -171,6 +171,14 @@ final class Money implements JsonSerializable, Arrayable, Wireable
         ]));
     }
 
+    /** Create a Money instance from a formatted string. */
+    public static function fromFormatted(string $formatted, Currency|string $currency = null, mixed ...$overrides): self
+    {
+        $decimal = PriceFormatter::resolve($formatted, currency($currency), variadic_array($overrides));
+
+        return static::fromDecimal($decimal, currency($currency));
+    }
+
     /** Get the string representation of the Money instance. */
     public function __toString(): string
     {

--- a/src/Money.php
+++ b/src/Money.php
@@ -171,7 +171,13 @@ final class Money implements JsonSerializable, Arrayable, Wireable
         ]));
     }
 
-    /** Create a Money instance from a formatted string. */
+    /**
+     * Create a Money instance from a formatted string.
+     *
+     * @param  string  $formatted The string formatted using the `formatted()` or `rawFormatted()` method.
+     * @param  Currency|string|null  $currency The currency to use when passing the overrides. If not provided, the currency of the formatted string is used.
+     * @param  array  ...$overrides The overrides used when formatting the money instance.
+     */
     public static function fromFormatted(string $formatted, Currency|string $currency = null, mixed ...$overrides): self
     {
         $currency = isset($currency)

--- a/src/Money.php
+++ b/src/Money.php
@@ -36,7 +36,7 @@ final class Money implements JsonSerializable, Arrayable, Wireable
     public static function fromDecimal(float $decimal, Currency|string $currency = null): self
     {
         return new static(
-            (int) round($decimal * 10 ** currency($currency)->mathDecimals()),
+            (int) round($decimal * pow(10, currency($currency)->mathDecimals())),
             currency($currency)
         );
     }
@@ -154,7 +154,7 @@ final class Money implements JsonSerializable, Arrayable, Wireable
     /** Get the decimal representation of the value. */
     public function decimal(): float
     {
-        return $this->value / 10 ** $this->currency->mathDecimals();
+        return $this->value / pow(10, $this->currency->mathDecimals());
     }
 
     /** Format the value. */
@@ -228,7 +228,7 @@ final class Money implements JsonSerializable, Arrayable, Wireable
 
         return $this
             ->divideBy($this->currency->rate())
-            ->divideBy(10 ** $mathDecimalDifference)
+            ->divideBy(pow(10, $mathDecimalDifference))
             ->value();
     }
 
@@ -240,7 +240,7 @@ final class Money implements JsonSerializable, Arrayable, Wireable
         $mathDecimalDifference = $newCurrency->mathDecimals() - currencies()->getDefault()->mathDecimals();
 
         return new static(
-            (int) round($this->valueInDefaultCurrency() * $newCurrency->rate() * 10 ** $mathDecimalDifference, 0),
+            (int) round($this->valueInDefaultCurrency() * $newCurrency->rate() * pow(10, $mathDecimalDifference), 0),
             $currency
         );
     }

--- a/src/PriceFormatter.php
+++ b/src/PriceFormatter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ArchTech\Money;
 
 use ArchTech\Money\Exceptions\CannotExtractCurrencyException;
+use Exception;
 
 class PriceFormatter
 {
@@ -38,7 +39,7 @@ class PriceFormatter
         $removeNonDigits = preg_replace('/[^\d' . preg_quote($currency->decimalSeparator()) . ']/', '', $formatted);
 
         if (! is_string($removeNonDigits)) {
-            throw new \Exception('The formatted string could not be resolved to a valid number.');
+            throw new Exception('The formatted string could not be resolved to a valid number.');
         }
 
         return (float) str_replace($currency->decimalSeparator(), '.', $removeNonDigits);

--- a/src/PriceFormatter.php
+++ b/src/PriceFormatter.php
@@ -56,13 +56,13 @@ class PriceFormatter
                 && str_ends_with($formatted, $currency->suffix())
             ) {
                 if ($possibleCurrency) {
-                    throw new CannotExtractCurrencyException('Multiple currencies are using the same prefix and suffix. Please specify the currency of the formatted string.');
+                    throw new CannotExtractCurrencyException("Multiple currencies are using the same prefix and suffix as '$formatted'. Please specify the currency of the formatted string.");
                 }
 
                 $possibleCurrency = $currency;
             }
         }
 
-        return $possibleCurrency ?? throw new CannotExtractCurrencyException('None of the currencies are using the prefix and suffix that would match with the formatted string.');
+        return $possibleCurrency ?? throw new CannotExtractCurrencyException("None of the currencies are using the prefix and suffix that would match with the formatted string '$formatted'.");
     }
 }

--- a/src/PriceFormatter.php
+++ b/src/PriceFormatter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ArchTech\Money;
 
+use ArchTech\Money\Exceptions\CannotExtractCurrencyException;
+
 class PriceFormatter
 {
     /** Format a decimal per the currency's specifications. */
@@ -53,13 +55,13 @@ class PriceFormatter
                 && str_ends_with($formatted, $currency->suffix())
             ) {
                 if ($possibleCurrency) {
-                    throw new \Exception('Multiple currencies are using the same prefix and suffix. Please specify the currency of the formatted string.');
+                    throw new CannotExtractCurrencyException('Multiple currencies are using the same prefix and suffix. Please specify the currency of the formatted string.');
                 }
 
                 $possibleCurrency = $currency;
             }
         }
 
-        return $possibleCurrency ?? throw new \Exception('None of the currencies are using the prefix and suffix that would match with the formatted string.');
+        return $possibleCurrency ?? throw new CannotExtractCurrencyException('None of the currencies are using the prefix and suffix that would match with the formatted string.');
     }
 }

--- a/src/PriceFormatter.php
+++ b/src/PriceFormatter.php
@@ -23,7 +23,7 @@ class PriceFormatter
         return $currency->prefix() . $decimal . $currency->suffix();
     }
 
-    /** Extract the decimal from the formatter string as per the currency's specifications. */
+    /** Extract the decimal from the formatted string as per the currency's specifications. */
     public static function resolve(string $formatted, Currency $currency, array $overrides = []): float
     {
         $currency = Currency::fromArray(
@@ -40,5 +40,26 @@ class PriceFormatter
         }
 
         return (float) str_replace($currency->decimalSeparator(), '.', $removeNonDigits);
+    }
+
+    /** Tries to extract the currency from the formatted string. */
+    public static function extractCurrency(string $formatted): Currency
+    {
+        $possibleCurrency = null;
+
+        foreach (currencies()->all() as $currency) {
+            if (
+                str_starts_with($formatted, $currency->prefix())
+                && str_ends_with($formatted, $currency->suffix())
+            ) {
+                if ($possibleCurrency) {
+                    throw new \Exception('Multiple currencies are using the same prefix and suffix. Please specify the currency of the formatted string.');
+                }
+
+                $possibleCurrency = $currency;
+            }
+        }
+
+        return $possibleCurrency ?? throw new \Exception('None of the currencies are using the prefix and suffix that would match with the formatted string.');
     }
 }

--- a/src/PriceFormatter.php
+++ b/src/PriceFormatter.php
@@ -22,4 +22,19 @@ class PriceFormatter
 
         return $currency->prefix() . $decimal . $currency->suffix();
     }
+
+    /** Extract the decimal from the formatter string as per the currency's specifications. */
+    public static function resolve(string $formatted, Currency $currency, array $overrides = []): float
+    {
+        $currency = Currency::fromArray(
+            array_merge(currency($currency)->toArray(), $overrides)
+        );
+
+        $formatted = ltrim($formatted, $currency->prefix());
+        $formatted = rtrim($formatted, $currency->suffix());
+
+        $removeNonDigits = preg_replace('/[^\d'.preg_quote($currency->decimalSeparator()).']/', '', $formatted);
+
+        return (float) str_replace($currency->decimalSeparator(), '.', $removeNonDigits);
+    }
 }

--- a/src/PriceFormatter.php
+++ b/src/PriceFormatter.php
@@ -35,7 +35,7 @@ class PriceFormatter
 
         $removeNonDigits = preg_replace('/[^\d' . preg_quote($currency->decimalSeparator()) . ']/', '', $formatted);
 
-        if (!is_string($removeNonDigits)) {
+        if (! is_string($removeNonDigits)) {
             throw new \Exception('The formatted string could not be resolved to a valid number.');
         }
 

--- a/src/PriceFormatter.php
+++ b/src/PriceFormatter.php
@@ -35,6 +35,10 @@ class PriceFormatter
 
         $removeNonDigits = preg_replace('/[^\d'.preg_quote($currency->decimalSeparator()).']/', '', $formatted);
 
+        if (!is_string($removeNonDigits)) {
+            throw new \Exception('The formatted string could not be resolved to a valid number.');
+        }
+
         return (float) str_replace($currency->decimalSeparator(), '.', $removeNonDigits);
     }
 }

--- a/tests/Pest/MoneyTest.php
+++ b/tests/Pest/MoneyTest.php
@@ -147,6 +147,18 @@ test('money can be formatted without rounding', function () {
     )->toBe('10,34 Kč');
 });
 
+test('money can be created from a formatted string', function () {
+    $money = Money::fromFormatted('$10.40');
+    expect($money->value())->toBe(1040);
+});
+
+test('money can be created from a raw formatted string', function () {
+    currencies()->add([CZK::class]);
+
+    $money = Money::fromFormatted('1 234,56 Kč', CZK::class);
+    expect($money->value())->toBe(123456);
+});
+
 test('converting money to a string returns the formatted string', function () {
     expect(
         (string) Money::fromDecimal(10.00, USD::class)

--- a/tests/Pest/MoneyTest.php
+++ b/tests/Pest/MoneyTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use ArchTech\Money\Currencies\USD;
+use ArchTech\Money\Exceptions\CannotExtractCurrencyException;
 use ArchTech\Money\Money;
 use ArchTech\Money\Tests\Currencies\CZK;
 use ArchTech\Money\Tests\Currencies\EUR;
@@ -165,7 +166,7 @@ test('an exception is thrown if none of the currencies match the prefix and suff
 
     currencies()->remove(USD::class);
 
-    pest()->expectException(\Exception::class);
+    pest()->expectException(CannotExtractCurrencyException::class);
     Money::fromFormatted($formatted);
 });
 
@@ -173,7 +174,7 @@ test('an exception is thrown if multiple currencies are using the same prefix an
     currencies()->add(['code' => 'USD2', 'name' => 'USD2', 'prefix' => '$']);
     $money = money(1000);
 
-    pest()->expectException(\Exception::class);
+    pest()->expectException(CannotExtractCurrencyException::class);
     Money::fromFormatted($money->formatted());
 });
 

--- a/tests/Pest/MoneyTest.php
+++ b/tests/Pest/MoneyTest.php
@@ -159,6 +159,24 @@ test('money can be created from a raw formatted string', function () {
     expect($money->value())->toBe(123456);
 });
 
+test('an exception is thrown if none of the currencies match the prefix and suffix', function () {
+    $money = money(1000);
+    $formatted = $money->formatted();
+
+    currencies()->remove(USD::class);
+
+    pest()->expectException(\Exception::class);
+    Money::fromFormatted($formatted);
+});
+
+test('an exception is thrown if multiple currencies are using the same prefix and suffix', function () {
+    currencies()->add(['code' => 'USD2', 'name' => 'USD2', 'prefix' => '$']);
+    $money = money(1000);
+
+    pest()->expectException(\Exception::class);
+    Money::fromFormatted($money->formatted());
+});
+
 test('converting money to a string returns the formatted string', function () {
     expect(
         (string) Money::fromDecimal(10.00, USD::class)


### PR DESCRIPTION
This PR adds an additional method to create a money instance from a formatted string.

Changes overview:
- New static method `fromFormatted()` inside the `Money` class which:
	1. Accepts currency and currency configuration overrides (optional)
	2. Tries to extract the currency if it is not provided by the user
	3. Throws an exception if no currency matches the prefix and suffix of the formatted string
	4. Throws an exception if multiple currencies match the prefix and suffix of the formatted string
	5. Calls the `PriceFormatter::resolve()` to get the decimal value
- New static method `resolve()` inside the `PriceFormatter` class to manage the decimal extraction. A process on formatted string:
	1. Removes the prefix and suffix
	6. Removes everything other than the number of the decimal separator
	7. Replaces decimal formatted string with a . (period) to allow the following float conversion
	8. Converts to float and returns the decimal value
- New tests inside the `MoneyTest` class for the new method
- Readme updates to inform users about the new method's functionality
- Improve code readability by using the `pow()` PHP function


Closes https://github.com/archtechx/money/issues/1