### PR TITLE
Fixed larastan package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ composer.lock
 vendor/
 .php-cs-fixer.cache
 .vscode/
+.idea/
 coverage/
 node_modules

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "pestphp/pest": "^2.0",
         "phpstan/phpstan": "^1.9.8",
         "pestphp/pest-plugin-laravel": "^2.0",
-        "nunomaduro/larastan": "^2.4"
+        "larastan/larastan": "^2.4"
     },
     "extra": {
         "laravel": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - ./vendor/nunomaduro/larastan/extension.neon
+    - ./vendor/larastan/larastan/extension.neon
 
 parameters:
     paths:


### PR DESCRIPTION
Require larastan from `larastan/larastan` instead of `nunomaduro/larastan`.